### PR TITLE
Update test for version conflict handling

### DIFF
--- a/tests/test_aws_file_io.py
+++ b/tests/test_aws_file_io.py
@@ -27,6 +27,7 @@ import urllib3
 
 from mx8fs import (
     BinaryFileHandler,
+    VersionMismatchError,
     copy_file,
     delete_file,
     file_exists,
@@ -281,8 +282,9 @@ def test_update_file(tmp_path: Path) -> None:
         assert version_2 != version
 
         # Write and check we cannot overwrite the file
+        time.sleep(1)
         write_file(test_file, "test 3")
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(VersionMismatchError):
             update_file_if_version_matches(test_file, "test 4", version_2)
 
         assert read_file(test_file) == "test 3"


### PR DESCRIPTION
Modify the test to raise `VersionMismatchError` instead of `FileNotFoundError` when there are version conflicts during file updates.