### PR TITLE
fix: update error handling for version mismatch in file updates

### DIFF
--- a/mx8fs/file_io.py
+++ b/mx8fs/file_io.py
@@ -129,7 +129,7 @@ def update_file_if_version_matches(file: str, data: str, version: str) -> None:
         except s3_client.exceptions.NoSuchKey as exc:
             raise FileNotFoundError("File does not exist") from exc
         except s3_client.exceptions.ClientError as exc:
-            if exc.response["Error"]["Code"] in ["PreconditionFailed", "Conflict"]:
+            if exc.response["Error"]["Code"] in ["PreconditionFailed", "ConditionalRequestConflict"]:
                 raise VersionMismatchError(f"File with the etag {version} does not exist") from exc
             else:  # pragma: no cover
                 raise exc


### PR DESCRIPTION
This pull request makes a minor update to the `update_file_if_version_matches` function in the `mx8fs/file_io.py` file. The change refines error handling for `ClientError` exceptions by updating the list of error codes checked.

* [`mx8fs/file_io.py`](diffhunk://#diff-1eb097e1649c4c901fa4cf01206fda4013c51d59f3f22e6ff3f0c3d4fda5a256L132-R132): Updated the error code list to replace `"Conflict"` with `"ConditionalRequestConflict"` when handling `ClientError` exceptions. This ensures more precise handling of version mismatch scenarios.