### PR TITLE
Add configurable lock helper to JsonFileStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Below are the functions and classes exported by the library (`mx8fs.__all__`). P
 ### JSON Storage
 
 - `class JsonFileStorage(base_path: str, randomizer: Callable | None = None)`: Base class for simple JSON model storage.
-  - Methods: `list()`, `read(key)`, `write(model)`, `write_dict(dict, key=None)`, `update(model)`, `delete(key)`.
+  - Methods: `list()`, `read(key)`, `write(model)`, `write_dict(dict, key=None)`, `update(model)`, `delete(key)`, `get_lock(key, wait_period=0.1, time_out_seconds=840, maximum_age=900)`.
   - Implements unique key generation and defers serialization to subclass hooks.
 
   Example (using factory below for a Pydantic model): see next section.
@@ -286,7 +286,8 @@ Below are the functions and classes exported by the library (`mx8fs.__all__`). P
   store = UserStorage('/tmp/users')
 
   u = store.write(User(name='Ada'))     # auto-keyed
-  u = store.update(User(key=u.key, name='Ada Lovelace'))
+  with store.get_lock(u.key):
+      u = store.update(User(key=u.key, name='Ada Lovelace'))
   got = store.read(u.key)
   all_keys = store.list()
   store.delete(u.key)

--- a/mx8fs/storage.py
+++ b/mx8fs/storage.py
@@ -23,7 +23,7 @@ import string
 from collections.abc import Callable
 from typing import Any
 
-from mx8fs import delete_file, file_exists, list_files, read_file, write_file
+from mx8fs import FileLock, delete_file, file_exists, list_files, read_file, write_file
 
 
 class JsonFileStorage:
@@ -107,6 +107,21 @@ class JsonFileStorage:
     def delete(self, key: str) -> None:
         """Delete a file from storage."""
         delete_file(self._get_path(key))
+
+    def get_lock(
+        self,
+        key: str,
+        wait_period: float = 0.1,
+        time_out_seconds: int = 840,
+        maximum_age: int = 900,
+    ) -> FileLock:
+        """Get a file lock for the stored file."""
+        return FileLock(
+            self._get_path(key),
+            wait_period=wait_period,
+            time_out_seconds=time_out_seconds,
+            maximum_age=maximum_age,
+        )
 
     def _get_path(self, key: str) -> str:
         """Get the path for a file."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -19,13 +19,14 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 # pylint: disable=protected-access
 
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
 import pytest
 from pydantic import BaseModel
 
-from mx8fs import JsonFileStorage, json_file_storage_factory
+from mx8fs import FileLock, JsonFileStorage, json_file_storage_factory
 
 
 class StorageTestClass(BaseModel):
@@ -93,6 +94,29 @@ def test_get_path(file_storage: JsonFileStorage) -> None:
     path = file_storage._get_path("file1")
     expected_path = file_storage.base_path + "/file1.txt"
     assert path == expected_path
+
+
+def test_get_lock(file_storage: JsonFileStorage) -> None:
+    """Test the get_lock method."""
+    lock = file_storage.get_lock("file1")
+
+    assert isinstance(lock, FileLock)
+    assert lock.file == file_storage._get_path("file1")
+
+
+def test_get_lock_custom_parameters(file_storage: JsonFileStorage) -> None:
+    """Test the get_lock method with custom parameters."""
+    lock = file_storage.get_lock(
+        "file1",
+        wait_period=0.5,
+        time_out_seconds=10,
+        maximum_age=20,
+    )
+
+    assert lock.file == file_storage._get_path("file1")
+    assert lock.waiter.wait_period == 0.5
+    assert lock.waiter.time_out_seconds == 10
+    assert lock.maximum_age == timedelta(seconds=20)
 
 
 def test_get_unique_key(file_storage: JsonFileStorage) -> None:


### PR DESCRIPTION
## Summary
- Add `JsonFileStorage.get_lock(...)` as a thin wrapper around `mx8fs.FileLock`.
- Pass through wait, timeout, and maximum-age parameters.
- Document the helper and add storage tests for default and custom lock settings.

## Validation
- `black mx8fs/storage.py tests/test_storage.py`
- `ruff check mx8fs/storage.py tests/test_storage.py`
- `mypy mx8fs/storage.py tests/test_storage.py`
- `pytest tests`
- Codacy CLI touched-file analysis

Fixes #34